### PR TITLE
Fix video streaming

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,6 @@ module.exports = function resl (config) {
       } else {
         loader.progress = 0.75 * loader.progress + 0.25
       }
-      loader.ready = request.stream
       notifyProgress(name)
     }
 


### PR DESCRIPTION
For streamed videos, the video is considered to be loaded right away, and no time is given for 'canplay' and 'loadedmetadata' to be called. But they must be called before you can use the video, otherwise, the video will be unusuable on some devices(on my Macbook for instance. But it worked for Mikola for some reason). 

And this simple PR fixes that.

This resolves issue mikolalysenko/regl#282
