### PR TITLE
add type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+type Parser =
+  | ((data: any) => any)
+  | {
+      onData: (data: any) => any;
+      onDone?: () => void;
+    };
+
+interface Manifest {
+  src: string;
+  type?: "text" | "binary" | "image" | "video" | "audio";
+  parser?: Parser;
+  stream?: boolean;
+  credentials?: boolean;
+}
+
+declare var resl: (args: {
+  manifest: Record<string, Manifest>;
+  onDone: (assets: Record<string, any>) => void;
+  onProgress?: (progress: number, message: any) => void;
+  onError?: (error: Error) => void;
+}) => void;
+
+export default resl;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resl",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "A streaming resource loader",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
add typescript definition to `resl`.
most of type still be `any` because typescript still hard to infer nested `.manifest` field and prevent breaking change from old codebase as possible.
also increase version to `2.0.0` to prevent `1.x.x`'s user to download type definition